### PR TITLE
Preserve relative mode in G2204/G2205

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7611,15 +7611,17 @@ void process_next_command() {
 
 	// 2204 relative move use G90 G91
 	case 2204:
+                bool relative_mode_backup = relative_mode;
 		relative_mode = true;
 		gcode_G0_G1();
-		relative_mode = false;
+		relative_mode = relative_mode_backup;
 		break;
 
 	case 2205:
+                bool relative_mode_backup = relative_mode;
 		relative_mode = true;
 		gcode_get_destination_polor();
-		relative_mode = false;
+		relative_mode = relative_mode_backup;
 		break;
 	
 #endif // UARM_SWIFT


### PR DESCRIPTION
Do not switch to absolute mode in G2204/G2205 if relative mode was active before.